### PR TITLE
Add one-command online launcher with public URL and complete app scaffold

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+tracker.db
+__pycache__/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,7 @@
+FROM python:3.11-slim
+
+WORKDIR /app
+COPY . .
+
+EXPOSE 4173
+CMD ["python3", "server.py"]

--- a/README.md
+++ b/README.md
@@ -1,0 +1,71 @@
+# Djomla – komplett starten (lokal ODER online URL)
+
+Du wolltest: **"komplette App mit URL, sofort online starten"** ✅
+
+Das geht jetzt mit **einem Befehl**.
+
+---
+
+## Option A: Sofort ONLINE URL (für andere teilbar)
+
+Im Terminal:
+
+```bash
+cd /workspace/Djomla
+python3 start_online.py
+```
+
+Dann zeigt dir das Terminal eine öffentliche URL wie:
+
+`https://xxxx.trycloudflare.com`
+
+Diese URL kannst du direkt öffnen und weitergeben.
+
+> Hinweis: Die URL bleibt aktiv, solange das Terminal läuft.
+> Falls Tunnel-Download blockiert ist (Firmennetz/VPN), nutze Option B lokal oder ich richte dir Render als feste URL ein.
+
+---
+
+## Option B: Nur lokal testen
+
+```bash
+cd /workspace/Djomla
+python3 start_local.py
+```
+
+Dann im Browser:
+
+`http://localhost:4173`
+
+---
+
+## Welches Terminal?
+
+- Windows: PowerShell / Windows Terminal
+- Mac: Terminal
+- Linux: Terminal
+
+---
+
+## Stoppen
+
+Im laufenden Terminal: `Ctrl + C`
+
+---
+
+## Was schon fertig ist
+
+- Live-Countdown
+- Blink-/Warnfarben
+- ABGEFAHREN-Status
+- Innsbruck-Ankunft bestätigen
+- Verspätung eintragen
+
+---
+
+## Dateien kurz
+
+- `start_online.py` → startet App + öffentliche URL
+- `start_local.py` → startet nur lokal
+- `server.py` → Backend
+- `web/` → Weboberfläche

--- a/START_HIER.txt
+++ b/START_HIER.txt
@@ -1,0 +1,13 @@
+DJOMLA START
+
+ONLINE URL (sofort):
+1) cd /workspace/Djomla
+2) python3 start_online.py
+3) URL aus Terminal öffnen/teilen (https://....trycloudflare.com)
+
+LOKAL:
+1) cd /workspace/Djomla
+2) python3 start_local.py
+3) Browser: http://localhost:4173
+
+Stoppen: Ctrl + C

--- a/docs/vba-to-web-migration.md
+++ b/docs/vba-to-web-migration.md
@@ -1,0 +1,129 @@
+# VBA ➜ Moderne Web-App: Migrationsplan (Train Live Tracker)
+
+## 1) Analyse deiner aktuellen VBA-Logik
+
+Dein VBA-System macht im Kern bereits ein gutes Echtzeit-Monitoring:
+
+1. **Auto-Start/Stop beim Workbook Open/Close**
+2. **1-Sekunden-Tick** mit `Application.OnTime`
+3. **Robustes Parsing** von Abfahrtszeiten aus Zellen
+4. **Countdown-Berechnung** je Zug
+5. **Statuswechsel auf „ABGEFAHREN“** bei `rest <= 0`
+6. **Blinklogik:**
+   - Unter 5 Minuten blinkt Countdown-Feld
+   - Unter 1 Minute blinkt Zugnummer-Feld
+7. **Alarm einmalig pro Zug** (Beep + Popup)
+
+Diese Logik kann 1:1 in eine moderne Web-App überführt werden.
+
+---
+
+## 2) Zielarchitektur (Web)
+
+### Frontend (Operator UI)
+
+- Große tabellarische Live-Ansicht (wie dein Excel-Board)
+- Farbzonen + Blinkzustände + „ABGEFAHREN“-Badge
+- Filter (Linie, Ziel, Zeitraum, Status)
+- Vollbild-/Control-Room-Modus
+- Benachrichtigungscenter statt Excel-MsgBox
+
+### Backend
+
+- REST API für Stammdaten + Fahrten
+- WebSocket-Server für sekundengenaue Live-Updates
+- Scheduler/Worker für Tick-Logik und Alarm-Events
+- Regel-Engine für Warnzustände (5-Min/1-Min)
+
+### Datenbank
+
+- Tabellen: `trains`, `departures`, `alerts`, `events`, `users`
+- Audit-/Event-Log für Nachvollziehbarkeit
+- Historisierung „abgefahren“, Verspätung, Änderungen
+
+---
+
+## 3) Mapping: VBA → Web-Komponenten
+
+- `IBK_SystemStarten` → Service-Start + Initialisierung der offenen Fahrten
+- `IBK_Tick` → Worker-Loop (jede Sekunde) oder clientseitiger Countdown mit Server-Sync
+- `IBK_ParseDeparture` → Parser/Validator im Backend + Zeitzonenhandling
+- `IBK_Abgefahren()` / `IBK_AlarmGemacht()` → persistenter Zustand in DB
+- `MsgBox/Beep` → In-App Alert + optional Push/Audio + Eskalationsregeln
+- Zellfarben/Formatierungen → UI-State-Renderer (CSS-States)
+
+---
+
+## 4) Feature-Backlog
+
+### MVP (schnell online)
+
+1. Live-Tabelle mit Countdown
+2. Automatischer Statuswechsel auf „ABGEFAHREN“
+3. 5-Min- und 1-Min-Warnung (Blinkzustände)
+4. Basis-CRUD für Züge/Fahrten
+5. Rollen: Admin, Disponent, Viewer
+
+### Advanced ("krank modern")
+
+1. Echtzeit-Karte (Zugpositionen/Geo)
+2. Prognosen (Verspätung mit Heuristik/ML)
+3. Kollisionserkennung bei Gleis-/Umlaufkonflikten
+4. Multi-Bahnhof-Mandantenfähigkeit
+5. KPI-Dashboard (Pünktlichkeit, Auslastung, Alarme)
+6. Mobile App / PWA mit Push Notifications
+7. Integrationen (GTFS, interne APIs, CSV/Excel-Import)
+
+---
+
+## 5) UX-Richtung (dein Wunsch: sehr modern)
+
+- Dark-Theme als Standard (wie dein aktueller Look)
+- Große kontrastreiche Zahlen für Countdown
+- Sanfte Animationen statt aggressivem Flackern
+- Alarm-Prioritäten (Info/Warn/Kritisch)
+- Touch-friendly Bedienelemente für Leitstandscreens
+
+---
+
+## 6) Technische Empfehlung
+
+### Variante A (sehr produktiv)
+
+- Frontend: Next.js + TypeScript + Tailwind + TanStack Table
+- Backend: FastAPI + SQLAlchemy + PostgreSQL + Redis
+- Realtime: WebSocket + Redis Pub/Sub
+- Deployment: Docker + Railway/Fly/Render oder eigener VPS
+
+### Variante B (komplett TypeScript)
+
+- Frontend: Next.js
+- Backend: NestJS
+- DB: PostgreSQL (Prisma)
+- Realtime: Socket.IO
+
+---
+
+## 7) Projektplan in 4 Phasen
+
+1. **Phase 1 (1–2 Wochen):** Datenmodell, API, Auth, Grund-UI
+2. **Phase 2 (1 Woche):** Live-Tick, Warnregeln, Alarmcenter
+3. **Phase 3 (1 Woche):** Admin-Bereich, Import/Export, Historie
+4. **Phase 4 (laufend):** Map, Prognosen, Integrationen, Mobile
+
+---
+
+## 8) Antwort auf deine Frage
+
+Ja – ich kann das mit dir von Ende zu Ende bauen:
+
+- Architektur
+- MVP-Implementierung
+- UI/UX im modernen Stil
+- Feature-Erweiterungen
+- Deployment
+
+Wenn du willst, ist der nächste konkrete Schritt:
+
+1. Ich scaffold’e dir direkt ein **echtes Full-Stack-MVP** (Next.js + API + DB).
+2. Danach übernehmen wir deine bestehende Zuglogik vollständig in den neuen Live-Tracker.

--- a/render.yaml
+++ b/render.yaml
@@ -1,0 +1,8 @@
+services:
+  - type: web
+    name: djomla-live-tracker
+    env: python
+    plan: free
+    buildCommand: "echo 'No build step required'"
+    startCommand: "python3 server.py"
+    autoDeploy: true

--- a/server.py
+++ b/server.py
@@ -1,0 +1,297 @@
+#!/usr/bin/env python3
+import json
+import sqlite3
+from datetime import datetime, timedelta, timezone
+from http.server import SimpleHTTPRequestHandler, ThreadingHTTPServer
+from pathlib import Path
+from urllib.parse import parse_qs, urlparse
+
+ROOT = Path(__file__).resolve().parent
+WEB_DIR = ROOT / "web"
+DB_PATH = ROOT / "tracker.db"
+
+
+def utc_now() -> datetime:
+    return datetime.now(timezone.utc)
+
+
+def db_conn():
+    conn = sqlite3.connect(DB_PATH)
+    conn.row_factory = sqlite3.Row
+    return conn
+
+
+def parse_iso(ts: str) -> datetime:
+    return datetime.fromisoformat(ts.replace("Z", "+00:00")).astimezone(timezone.utc)
+
+
+def ensure_columns(conn: sqlite3.Connection):
+    cols = {r["name"] for r in conn.execute("PRAGMA table_info(trains)").fetchall()}
+    required = {
+        "innsbruck_arrival_at": "TEXT",
+        "arrival_confirmed": "INTEGER DEFAULT 0",
+        "arrival_prompted_at": "TEXT",
+        "delay_minutes": "INTEGER DEFAULT 0",
+    }
+    for col, ddl in required.items():
+        if col not in cols:
+            conn.execute(f"ALTER TABLE trains ADD COLUMN {col} {ddl}")
+
+
+def init_db():
+    conn = db_conn()
+    with conn:
+        conn.execute(
+            """
+            CREATE TABLE IF NOT EXISTS trains (
+              id INTEGER PRIMARY KEY AUTOINCREMENT,
+              route TEXT NOT NULL,
+              train_no TEXT NOT NULL,
+              start_station TEXT NOT NULL,
+              departure_at TEXT NOT NULL,
+              innsbruck_arrival_at TEXT,
+              note TEXT DEFAULT '',
+              departed INTEGER DEFAULT 0,
+              alarmed INTEGER DEFAULT 0,
+              arrival_confirmed INTEGER DEFAULT 0,
+              arrival_prompted_at TEXT,
+              delay_minutes INTEGER DEFAULT 0,
+              created_at TEXT NOT NULL
+            )
+            """
+        )
+        ensure_columns(conn)
+
+    count = conn.execute("SELECT COUNT(*) FROM trains").fetchone()[0]
+    if count == 0:
+        now = utc_now()
+        seeds = [
+            ("Railjet → Wien", "867", "Bregenz", 6, 12, "Wendet auf 666"),
+            ("Railjet → Wien", "163", "Buchs", 2, 7, "Aus 164"),
+            ("Nightjet → Graz", "465", "Buchs", 1, 4, "LOK&KLASSEN"),
+            ("DANI → München", "286", "Innsbruck", -2, -1, "ABGEFAHREN Demo"),
+        ]
+        with conn:
+            for route, train_no, start, arrival_offset_min, dep_offset_min, note in seeds:
+                arrival_at = (now + timedelta(minutes=arrival_offset_min)).isoformat()
+                departure_at = (now + timedelta(minutes=dep_offset_min)).isoformat()
+                conn.execute(
+                    """
+                    INSERT INTO trains(
+                      route, train_no, start_station, departure_at, innsbruck_arrival_at, note, created_at
+                    ) VALUES(?,?,?,?,?,?,?)
+                    """,
+                    (route, train_no, start, departure_at, arrival_at, note, now.isoformat()),
+                )
+
+    # Backfill old rows
+    with conn:
+        conn.execute(
+            """
+            UPDATE trains
+            SET innsbruck_arrival_at = datetime(departure_at, '-30 minutes')
+            WHERE innsbruck_arrival_at IS NULL
+            """
+        )
+    conn.close()
+
+
+def serialize_train(row: sqlite3.Row):
+    now = utc_now()
+    departure = parse_iso(row["departure_at"])
+    inns_arrival = parse_iso(row["innsbruck_arrival_at"])
+    rest = int((departure - now).total_seconds())
+    arrival_rest = int((inns_arrival - now).total_seconds())
+    departed = row["departed"] == 1 or rest <= 0
+
+    prompted_at = row["arrival_prompted_at"]
+    arrival_window_active = False
+    if prompted_at:
+        prompt_dt = parse_iso(prompted_at)
+        arrival_window_active = (now - prompt_dt).total_seconds() <= 10
+
+    return {
+        "id": row["id"],
+        "route": row["route"],
+        "trainNo": row["train_no"],
+        "start": row["start_station"],
+        "departureAt": row["departure_at"],
+        "innsbruckArrivalAt": row["innsbruck_arrival_at"],
+        "note": row["note"],
+        "departed": departed,
+        "alarmed": row["alarmed"] == 1,
+        "restSeconds": rest,
+        "arrivalRestSeconds": arrival_rest,
+        "arrivalConfirmed": row["arrival_confirmed"] == 1,
+        "arrivalWindowActive": arrival_window_active,
+        "delayMinutes": row["delay_minutes"] or 0,
+    }
+
+
+class Handler(SimpleHTTPRequestHandler):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, directory=str(WEB_DIR), **kwargs)
+
+    def _json(self, payload, status=200):
+        data = json.dumps(payload).encode("utf-8")
+        self.send_response(status)
+        self.send_header("Content-Type", "application/json; charset=utf-8")
+        self.send_header("Content-Length", str(len(data)))
+        self.end_headers()
+        self.wfile.write(data)
+
+    def _read_json(self):
+        length = int(self.headers.get("Content-Length", "0"))
+        if length == 0:
+            return {}
+        return json.loads(self.rfile.read(length).decode("utf-8"))
+
+    def do_GET(self):
+        parsed = urlparse(self.path)
+        if parsed.path == "/api/trains":
+            q = parse_qs(parsed.query)
+            search = q.get("search", [""])[0].strip().lower()
+            conn = db_conn()
+            rows = conn.execute("SELECT * FROM trains ORDER BY departure_at").fetchall()
+            conn.close()
+            trains = [serialize_train(r) for r in rows]
+            if search:
+                trains = [
+                    t
+                    for t in trains
+                    if search in f"{t['route']} {t['trainNo']} {t['start']} {t['note']}".lower()
+                ]
+            self._json({"trains": trains, "serverTime": utc_now().isoformat()})
+            return
+
+        if parsed.path == "/api/health":
+            self._json({"ok": True, "time": utc_now().isoformat()})
+            return
+
+        return super().do_GET()
+
+    def do_POST(self):
+        if self.path == "/api/trains":
+            body = self._read_json()
+            now = utc_now()
+            dep_iso = body.get("departureAt")
+            arrival_iso = body.get("innsbruckArrivalAt")
+            try:
+                parse_iso(dep_iso)
+                parse_iso(arrival_iso)
+            except Exception:
+                self._json({"error": "departureAt and innsbruckArrivalAt must be ISO datetime"}, 400)
+                return
+
+            conn = db_conn()
+            with conn:
+                cur = conn.execute(
+                    """
+                    INSERT INTO trains(
+                      route, train_no, start_station, departure_at, innsbruck_arrival_at,
+                      note, created_at
+                    ) VALUES(?,?,?,?,?,?,?)
+                    """,
+                    (
+                        body.get("route", "Railjet → Vorarlberg"),
+                        body.get("trainNo", "000"),
+                        body.get("start", "Innsbruck"),
+                        dep_iso,
+                        arrival_iso,
+                        body.get("note", "Dynamisch hinzugefügt"),
+                        now.isoformat(),
+                    ),
+                )
+                row = conn.execute("SELECT * FROM trains WHERE id=?", (cur.lastrowid,)).fetchone()
+            conn.close()
+            self._json({"train": serialize_train(row)}, 201)
+            return
+
+        if self.path == "/api/arrival-confirmation":
+            body = self._read_json()
+            train_id = body.get("trainId")
+            is_present = bool(body.get("isPresent"))
+            delay_minutes = int(body.get("delayMinutes", 0))
+
+            conn = db_conn()
+            row = conn.execute("SELECT * FROM trains WHERE id=?", (train_id,)).fetchone()
+            if not row:
+                conn.close()
+                self._json({"error": "train not found"}, 404)
+                return
+
+            with conn:
+                if is_present:
+                    conn.execute(
+                        "UPDATE trains SET arrival_confirmed=1 WHERE id=?",
+                        (train_id,),
+                    )
+                else:
+                    base_arrival = parse_iso(row["innsbruck_arrival_at"])
+                    base_departure = parse_iso(row["departure_at"])
+                    new_arrival = base_arrival + timedelta(minutes=delay_minutes)
+                    new_departure = base_departure + timedelta(minutes=delay_minutes)
+                    conn.execute(
+                        """
+                        UPDATE trains
+                        SET innsbruck_arrival_at=?, departure_at=?, delay_minutes=delay_minutes+?,
+                            arrival_prompted_at=NULL, arrival_confirmed=0
+                        WHERE id=?
+                        """,
+                        (new_arrival.isoformat(), new_departure.isoformat(), delay_minutes, train_id),
+                    )
+            conn.close()
+            self._json({"ok": True})
+            return
+
+        if self.path == "/api/tick":
+            conn = db_conn()
+            departure_alerts = []
+            arrival_checks = []
+            now = utc_now()
+
+            with conn:
+                rows = conn.execute("SELECT * FROM trains").fetchall()
+                for row in rows:
+                    train = serialize_train(row)
+
+                    if train["departed"] and not train["alarmed"]:
+                        conn.execute("UPDATE trains SET departed=1, alarmed=1 WHERE id=?", (row["id"],))
+                        departure_alerts.append({"id": row["id"], "trainNo": row["train_no"]})
+                    elif train["departed"]:
+                        conn.execute("UPDATE trains SET departed=1 WHERE id=?", (row["id"],))
+
+                    should_check_arrival = (
+                        train["arrivalRestSeconds"] <= 0
+                        and not train["arrivalConfirmed"]
+                        and row["arrival_prompted_at"] is None
+                    )
+                    if should_check_arrival:
+                        conn.execute(
+                            "UPDATE trains SET arrival_prompted_at=? WHERE id=?",
+                            (now.isoformat(), row["id"]),
+                        )
+                        arrival_checks.append(
+                            {
+                                "id": row["id"],
+                                "trainNo": row["train_no"],
+                                "innsbruckArrivalAt": row["innsbruck_arrival_at"],
+                            }
+                        )
+
+            conn.close()
+            self._json({"alerts": departure_alerts, "arrivalChecks": arrival_checks})
+            return
+
+        self.send_error(404, "Not found")
+
+
+def main():
+    init_db()
+    server = ThreadingHTTPServer(("0.0.0.0", 4173), Handler)
+    print("Serving app+API on http://0.0.0.0:4173")
+    server.serve_forever()
+
+
+if __name__ == "__main__":
+    main()

--- a/start_local.py
+++ b/start_local.py
@@ -1,0 +1,83 @@
+#!/usr/bin/env python3
+"""One-click local launcher for non-technical users.
+
+- Starts Djomla server on port 4173
+- Tries to open the browser automatically
+- Always prints the exact URL to click/copy
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+import time
+import webbrowser
+from pathlib import Path
+
+PORT = 4173
+URL = f"http://localhost:{PORT}"
+
+
+def _try_open_browser(url: str) -> bool:
+    """Best-effort browser open across environments."""
+    try:
+        if webbrowser.open(url):
+            return True
+    except Exception:
+        pass
+
+    # Fallback commands (Linux desktop environments)
+    for cmd in (["xdg-open", url], ["gio", "open", url]):
+        try:
+            result = subprocess.run(cmd, check=False, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+            if result.returncode == 0:
+                return True
+        except Exception:
+            continue
+
+    return False
+
+
+def main() -> int:
+    repo_dir = Path(__file__).resolve().parent
+    server_file = repo_dir / "server.py"
+
+    if not server_file.exists():
+        print("❌ Fehler: server.py wurde nicht gefunden.")
+        return 1
+
+    print("=" * 64)
+    print("✅ Djomla startet jetzt")
+    print(f"🌐 URL: {URL}")
+    print("⛔ Stoppen: im Terminal Ctrl + C")
+    print("=" * 64)
+
+    process = subprocess.Popen(
+        [sys.executable, str(server_file)],
+        cwd=str(repo_dir),
+        env=os.environ.copy(),
+    )
+
+    try:
+        time.sleep(1.2)
+        opened = _try_open_browser(URL)
+        if opened:
+            print("✅ Browser wurde geöffnet.")
+        else:
+            print("⚠️ Browser konnte nicht automatisch geöffnet werden.")
+            print(f"👉 Bitte diese Adresse manuell öffnen: {URL}")
+
+        return process.wait()
+    except KeyboardInterrupt:
+        print("\n🛑 Stoppe Djomla...")
+        process.terminate()
+        try:
+            process.wait(timeout=5)
+        except subprocess.TimeoutExpired:
+            process.kill()
+        return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/start_online.py
+++ b/start_online.py
@@ -1,0 +1,167 @@
+#!/usr/bin/env python3
+"""Start Djomla and expose it with a public URL via Cloudflare Quick Tunnel.
+
+Usage:
+  python3 start_online.py
+"""
+
+from __future__ import annotations
+
+import os
+import platform
+import re
+import shutil
+import stat
+import subprocess
+import sys
+import tempfile
+import time
+import urllib.request
+from pathlib import Path
+
+PORT = 4173
+LOCAL_URL = f"http://127.0.0.1:{PORT}"
+ROOT = Path(__file__).resolve().parent
+BIN_DIR = ROOT / ".tools"
+CF_BIN = BIN_DIR / "cloudflared"
+CF_URL_PATTERN = re.compile(r"https://[-a-zA-Z0-9]+\.trycloudflare\.com")
+
+
+def _download_cloudflared() -> Path:
+    system = platform.system().lower()
+    machine = platform.machine().lower()
+
+    if system != "linux":
+        raise RuntimeError("Automatischer Download ist aktuell nur für Linux vorbereitet.")
+
+    if machine in {"x86_64", "amd64"}:
+        url = "https://github.com/cloudflare/cloudflared/releases/latest/download/cloudflared-linux-amd64"
+    elif machine in {"aarch64", "arm64"}:
+        url = "https://github.com/cloudflare/cloudflared/releases/latest/download/cloudflared-linux-arm64"
+    else:
+        raise RuntimeError(f"Nicht unterstützte CPU-Architektur: {machine}")
+
+    BIN_DIR.mkdir(parents=True, exist_ok=True)
+    tmp_file = None
+    try:
+        with tempfile.NamedTemporaryFile(delete=False) as tmp:
+            tmp_file = Path(tmp.name)
+        print("⬇️  Lade cloudflared herunter...")
+        urllib.request.urlretrieve(url, tmp_file)
+        shutil.move(str(tmp_file), CF_BIN)
+        CF_BIN.chmod(CF_BIN.stat().st_mode | stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH)
+    finally:
+        if tmp_file and tmp_file.exists():
+            tmp_file.unlink(missing_ok=True)
+
+    return CF_BIN
+
+
+def ensure_cloudflared() -> Path:
+    system_path = shutil.which("cloudflared")
+    if system_path:
+        return Path(system_path)
+
+    if CF_BIN.exists():
+        return CF_BIN
+
+    return _download_cloudflared()
+
+
+def wait_for_local_server(timeout_s: float = 15.0) -> bool:
+    start = time.time()
+    while time.time() - start < timeout_s:
+        try:
+            with urllib.request.urlopen(f"{LOCAL_URL}/api/health", timeout=2) as resp:
+                if resp.status == 200:
+                    return True
+        except Exception:
+            time.sleep(0.5)
+    return False
+
+
+def start_server() -> subprocess.Popen:
+    return subprocess.Popen([sys.executable, str(ROOT / "server.py")], cwd=str(ROOT), env=os.environ.copy())
+
+
+def start_tunnel(cloudflared_bin: Path) -> tuple[subprocess.Popen, str | None]:
+    proc = subprocess.Popen(
+        [str(cloudflared_bin), "tunnel", "--url", LOCAL_URL, "--no-autoupdate"],
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        text=True,
+        cwd=str(ROOT),
+    )
+
+    public_url: str | None = None
+    start = time.time()
+    while time.time() - start < 25:
+        line = proc.stdout.readline() if proc.stdout else ""
+        if not line:
+            if proc.poll() is not None:
+                break
+            continue
+        match = CF_URL_PATTERN.search(line)
+        if match:
+            public_url = match.group(0)
+            break
+
+    return proc, public_url
+
+
+def main() -> int:
+    print("=" * 68)
+    print("🚀 Djomla startet ONLINE mit öffentlicher URL")
+    print("ℹ️  Zum Stoppen: Ctrl + C")
+    print("=" * 68)
+
+    server = start_server()
+    tunnel = None
+    try:
+        if not wait_for_local_server():
+            print("❌ Server konnte lokal nicht gestartet werden.")
+            return 1
+
+        print(f"✅ Lokal läuft: {LOCAL_URL}")
+        try:
+            cloudflared_bin = ensure_cloudflared()
+        except Exception as exc:
+            print("❌ Online-Tunnel konnte nicht vorbereitet werden.")
+            print(f"👉 Grund: {exc}")
+            print("👉 Lösung: cloudflared manuell installieren ODER Render/Docker Deploy nutzen.")
+            return 1
+
+        tunnel, public_url = start_tunnel(cloudflared_bin)
+
+        if not public_url:
+            print("❌ Konnte keine öffentliche URL erzeugen.")
+            print("👉 Prüfe Internetzugang und versuche erneut.")
+            return 1
+
+        print("\n" + "=" * 68)
+        print("✅ ONLINE URL (sofort teilbar):")
+        print(public_url)
+        print("=" * 68 + "\n")
+
+        # Keep both processes alive.
+        return server.wait()
+    except KeyboardInterrupt:
+        print("\n🛑 Stoppe Djomla + Tunnel...")
+        return 0
+    finally:
+        if tunnel and tunnel.poll() is None:
+            tunnel.terminate()
+            try:
+                tunnel.wait(timeout=5)
+            except subprocess.TimeoutExpired:
+                tunnel.kill()
+        if server.poll() is None:
+            server.terminate()
+            try:
+                server.wait(timeout=5)
+            except subprocess.TimeoutExpired:
+                server.kill()
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/web/app.js
+++ b/web/app.js
@@ -1,0 +1,204 @@
+const BLINK_J_SECONDS = 300;
+const BLINK_B_SECONDS = 60;
+
+const state = {
+  soundOn: true,
+  search: '',
+  trains: [],
+  loading: false,
+};
+
+const rowsEl = document.getElementById('trainRows');
+const clockEl = document.getElementById('clock');
+const runtimeStatus = document.getElementById('runtimeStatus');
+const alertList = document.getElementById('alertList');
+const search = document.getElementById('search');
+
+const timeFmt = new Intl.DateTimeFormat('de-AT', {
+  hour: '2-digit',
+  minute: '2-digit',
+  second: '2-digit',
+});
+
+function countdown(seconds) {
+  const s = Math.max(seconds, 0);
+  const h = String(Math.floor(s / 3600)).padStart(2, '0');
+  const m = String(Math.floor((s % 3600) / 60)).padStart(2, '0');
+  const sec = String(s % 60).padStart(2, '0');
+  return `${h}:${m}:${sec}`;
+}
+
+function addAlert(msg) {
+  const li = document.createElement('li');
+  li.textContent = `${timeFmt.format(new Date())} — ${msg}`;
+  alertList.prepend(li);
+  while (alertList.children.length > 14) alertList.removeChild(alertList.lastChild);
+}
+
+function beep() {
+  if (!state.soundOn) return;
+  const Ctx = window.AudioContext || window.webkitAudioContext;
+  if (!Ctx) return;
+  const ctx = new Ctx();
+  const osc = ctx.createOscillator();
+  const gain = ctx.createGain();
+  osc.connect(gain);
+  gain.connect(ctx.destination);
+  osc.frequency.value = 880;
+  gain.gain.value = 0.05;
+  osc.start();
+  setTimeout(() => {
+    osc.stop();
+    ctx.close();
+  }, 120);
+}
+
+async function fetchTrains() {
+  const q = encodeURIComponent(state.search);
+  const res = await fetch(`/api/trains?search=${q}`);
+  if (!res.ok) throw new Error('API error');
+  const data = await res.json();
+  state.trains = data.trains;
+  runtimeStatus.textContent = 'RUNNING';
+}
+
+async function handleArrivalCheck(check) {
+  addAlert(`Zug ${check.trainNo} soll jetzt in Innsbruck sein. Bitte bestätigen.`);
+  beep();
+
+  const present = window.confirm(
+    `Zug ${check.trainNo}: Ist der Zug wirklich in Innsbruck angekommen?\n\nOK = Ja\nAbbrechen = Nein (Verspätung eingeben)`
+  );
+
+  let payload = { trainId: check.id, isPresent: present };
+  if (!present) {
+    const value = window.prompt(`Wie viele Minuten Verspätung hat Zug ${check.trainNo}?`, '5');
+    const parsed = Number.parseInt(value ?? '0', 10);
+    const delayMinutes = Number.isFinite(parsed) && parsed > 0 ? parsed : 0;
+    payload = { ...payload, delayMinutes };
+    addAlert(
+      delayMinutes > 0
+        ? `Zug ${check.trainNo} mit +${delayMinutes} Min Verspätung verschoben.`
+        : `Zug ${check.trainNo} nicht bestätigt (keine Zusatz-Verspätung eingetragen).`
+    );
+  } else {
+    addAlert(`Ankunft von Zug ${check.trainNo} in Innsbruck bestätigt.`);
+  }
+
+  await fetch('/api/arrival-confirmation', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(payload),
+  });
+}
+
+async function tick() {
+  try {
+    const res = await fetch('/api/tick', { method: 'POST' });
+    if (!res.ok) return;
+    const data = await res.json();
+
+    for (const alert of data.alerts || []) {
+      addAlert(`Zug ${alert.trainNo} fährt JETZT ab!`);
+      beep();
+    }
+
+    for (const check of data.arrivalChecks || []) {
+      await handleArrivalCheck(check);
+    }
+  } catch {
+    runtimeStatus.textContent = 'OFFLINE';
+  }
+}
+
+function render() {
+  const now = new Date();
+  clockEl.textContent = timeFmt.format(now);
+  rowsEl.innerHTML = '';
+
+  for (const train of state.trains) {
+    const rest = train.restSeconds;
+    const departed = train.departed || rest <= 0;
+
+    const tr = document.createElement('tr');
+    if (rest <= 600 && rest > 0) tr.classList.add('row-near');
+
+    const statusClass = departed ? 'badge badge-departed' : 'badge badge-live';
+    const statusLabel = departed ? 'ABGEFAHREN' : 'LIVE';
+
+    let cdClass = 'countdown good';
+    if (rest <= 600 && rest > BLINK_J_SECONDS) cdClass = 'countdown warn'; // 10-5 Min orange
+    if (rest <= BLINK_J_SECONDS && rest > 0) cdClass = 'countdown danger blink-j'; // 5-1 Min rot+blink
+    if (departed) cdClass = 'countdown departed';
+
+    const trainNoClass = rest <= BLINK_B_SECONDS && rest > 0 ? 'trainno blink-b' : 'trainno'; // 1 Min bis Abfahrt
+
+    const dep = new Date(train.departureAt);
+    const ibkArrival = new Date(train.innsbruckArrivalAt);
+    const arrivalClass = train.arrivalWindowActive ? 'arrival-glow' : '';
+
+    tr.innerHTML = `
+      <td>${train.route}</td>
+      <td class="${trainNoClass}">${train.trainNo}</td>
+      <td>${train.start}</td>
+      <td class="${arrivalClass}">${timeFmt.format(ibkArrival)}</td>
+      <td>${timeFmt.format(dep)}</td>
+      <td><span class="${statusClass}">${statusLabel}</span></td>
+      <td class="${cdClass}">${departed ? 'ABGEFAHREN' : countdown(rest)}</td>
+      <td>${train.delayMinutes ? `+${train.delayMinutes} Min` : '-'}</td>
+      <td>${train.note || ''}</td>
+    `;
+    rowsEl.appendChild(tr);
+  }
+}
+
+async function refresh() {
+  if (state.loading) return;
+  state.loading = true;
+  try {
+    await tick();
+    await fetchTrains();
+  } catch {
+    runtimeStatus.textContent = 'OFFLINE';
+  } finally {
+    state.loading = false;
+    render();
+  }
+}
+
+document.getElementById('toggleSound').addEventListener('click', (e) => {
+  state.soundOn = !state.soundOn;
+  e.target.textContent = `🔔 Sound: ${state.soundOn ? 'AN' : 'AUS'}`;
+});
+
+document.getElementById('addDemoTrain').addEventListener('click', async () => {
+  const innsbruckArrivalAt = new Date(Date.now() + 90 * 1000).toISOString();
+  const departureAt = new Date(Date.now() + 2 * 60_000).toISOString();
+  const body = {
+    route: 'Railjet → Vorarlberg',
+    trainNo: String(Math.floor(Math.random() * 900) + 100),
+    start: 'Innsbruck',
+    innsbruckArrivalAt,
+    departureAt,
+    note: 'Dynamisch hinzugefügt',
+  };
+
+  const res = await fetch('/api/trains', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(body),
+  });
+
+  if (res.ok) {
+    addAlert('Neuer Demo-Zug wurde hinzugefügt.');
+    await refresh();
+  }
+});
+
+search.addEventListener('input', async (e) => {
+  state.search = e.target.value.trim();
+  await refresh();
+});
+
+setInterval(refresh, 1000);
+refresh();

--- a/web/index.html
+++ b/web/index.html
@@ -1,0 +1,58 @@
+<!doctype html>
+<html lang="de">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>IBK Live Train Tracker MVP</title>
+  <link rel="stylesheet" href="./styles.css" />
+</head>
+<body>
+  <main class="layout">
+    <header class="topbar">
+      <div>
+        <h1>IBK Live Tracker</h1>
+        <p class="sub">Modernes MVP – basierend auf deiner VBA-Logik</p>
+      </div>
+      <div class="status-box">
+        <span id="runtimeStatus">RUNNING</span>
+        <span id="clock">--:--:--</span>
+      </div>
+    </header>
+
+    <section class="controls">
+      <label>
+        Suchbegriff
+        <input id="search" type="text" placeholder="Zugnummer, Ziel, Route..." />
+      </label>
+      <button id="toggleSound">🔔 Sound: AN</button>
+      <button id="addDemoTrain">+ Demo-Zug in 2 Min</button>
+    </section>
+
+    <section class="board">
+      <table>
+        <thead>
+          <tr>
+            <th>Route</th>
+            <th>ZugNr</th>
+            <th>Start</th>
+            <th>Ankunft Innsbruck</th>
+            <th>Abfahrt</th>
+            <th>Status</th>
+            <th>Countdown</th>
+            <th>Verspätung</th>
+            <th>Hinweis</th>
+          </tr>
+        </thead>
+        <tbody id="trainRows"></tbody>
+      </table>
+    </section>
+
+    <aside class="alerts">
+      <h2>Alarm Center</h2>
+      <ul id="alertList"></ul>
+    </aside>
+  </main>
+
+  <script src="./app.js"></script>
+</body>
+</html>

--- a/web/styles.css
+++ b/web/styles.css
@@ -1,0 +1,131 @@
+:root {
+  --bg: #07090d;
+  --panel: #0f141d;
+  --line: #242d3b;
+  --text: #e7ecf3;
+  --muted: #8b96a9;
+  --good: #00e283;
+  --warn: #ff9f43;
+  --danger: #ff4d4d;
+}
+
+* { box-sizing: border-box; }
+body {
+  margin: 0;
+  font-family: Inter, Segoe UI, Roboto, Arial, sans-serif;
+  background: radial-gradient(circle at top, #101827 0%, var(--bg) 70%);
+  color: var(--text);
+}
+.layout {
+  width: min(1400px, 96vw);
+  margin: 18px auto 26px;
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: 14px;
+}
+.topbar, .controls, .board, .alerts {
+  background: linear-gradient(180deg, #121a26, var(--panel));
+  border: 1px solid var(--line);
+  border-radius: 14px;
+  padding: 14px;
+}
+.topbar {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+h1 { margin: 0; font-size: 1.5rem; }
+.sub { margin: 4px 0 0; color: var(--muted); }
+.status-box {
+  display: grid;
+  gap: 4px;
+  text-align: right;
+  font-weight: 700;
+}
+#clock { font-size: 1.2rem; }
+.controls {
+  display: flex;
+  gap: 10px;
+  flex-wrap: wrap;
+  align-items: end;
+}
+input, button {
+  background: #0d131d;
+  color: var(--text);
+  border: 1px solid #2a3446;
+  padding: 10px;
+  border-radius: 10px;
+}
+button { cursor: pointer; }
+.board { overflow-x: auto; }
+table {
+  width: 100%;
+  border-collapse: collapse;
+  min-width: 920px;
+}
+th, td {
+  border-bottom: 1px solid #1f2937;
+  padding: 10px 8px;
+  text-align: left;
+}
+th { color: #9db0cf; font-size: 0.85rem; text-transform: uppercase; }
+tr.row-near { background: rgba(255, 255, 255, 0.04); }
+.badge {
+  border-radius: 999px;
+  padding: 2px 8px;
+  font-size: 0.8rem;
+  border: 1px solid transparent;
+}
+.badge-live { border-color: #2954b8; color: #90bbff; }
+.badge-departed { border-color: #5f2a2a; background: #411919; color: #ffd7d7; }
+.countdown {
+  font-weight: 800;
+  font-size: 1.08rem;
+  letter-spacing: 0.04em;
+  text-align: center;
+}
+.countdown.good { color: var(--good); }
+.countdown.warn { color: var(--warn); }
+.countdown.departed { color: #c2c2c2; }
+.countdown.danger { color: var(--danger); }
+.countdown.blink-j {
+  animation: blinkRed 1s steps(1) infinite;
+}
+.trainno.blink-b {
+  animation: blinkStrong 1s steps(1) infinite;
+}
+
+.arrival-glow {
+  color: #7dff95;
+  font-weight: 800;
+  animation: arrivalPulse 1s ease-in-out 10;
+}
+.alerts h2 { margin: 0 0 8px; }
+.alerts ul {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+  display: grid;
+  gap: 8px;
+}
+.alerts li {
+  background: #0d131d;
+  border: 1px solid #2a3446;
+  border-left: 4px solid var(--warn);
+  border-radius: 8px;
+  padding: 8px;
+  font-size: 0.9rem;
+}
+@keyframes blinkRed {
+  0%, 49% { color: #ff4d4d; opacity: 1; }
+  50%, 100% { color: #ff4d4d; opacity: 0.2; }
+}
+@keyframes blinkStrong {
+  0%, 49% { background: #ff0000; color: white; }
+  50%, 100% { background: transparent; color: var(--text); }
+}
+
+@keyframes arrivalPulse {
+  0%, 100% { background: transparent; box-shadow: none; }
+  50% { background: rgba(0, 255, 120, 0.18); box-shadow: 0 0 14px rgba(0, 255, 120, 0.4); }
+}


### PR DESCRIPTION
### Motivation

- Provide a single, non-technical command to start the complete app and obtain a shareable public URL so the app can be used immediately.
- Offer a robust local fallback for environments where a public tunnel is not possible or blocked.
- Make the start flow explicit and friendly for non-developers with clear runtime messages and a tiny quick-start file.

### Description

- Add `start_online.py` which starts the local server, locates or downloads `cloudflared`, opens a Cloudflare Quick Tunnel and prints the public `https://...trycloudflare.com` URL, with graceful handling when tunnel setup fails.
- Add `start_local.py` as a one-click local launcher that starts the server and tries to open the browser while always printing the local URL `http://localhost:4173`.
- Add the full app scaffold including `server.py` (backend and API), `web/` (frontend: `index.html`, `app.js`, `styles.css`), `README.md`, `START_HIER.txt`, `render.yaml`, `Dockerfile`, and `.gitignore` to support both local and hosted runs.
- Improve tunnel error handling so blocked/forbidden downloads produce a friendly explanation and actionable suggestions instead of a traceback.

### Testing

- Ran `python3 -m py_compile server.py start_local.py start_online.py` which completed successfully.
- Verified the backend by launching `server.py` briefly and calling the health endpoint (`curl http://127.0.0.1:4173/api/health`), which returned `{ "ok": true, ... }`.
- Executed `start_online.py` under a short timeout in this environment where the automatic `cloudflared` download is blocked, and confirmed the script now reports a clear error message describing the `403 Forbidden` download failure and suggests manual installation or a hosted deploy as a fallback.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69921c0a759483238a4c540caaa5f16b)